### PR TITLE
fix: Add file info endpoint

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "Samurai-Backend"
-version = "0.15.0"
+version = "0.15.1"
 description = "Backend part of the Samurai project"
 authors = [
     {name = "Pavlo Pohorieltsev", email = "hdydpavel@gmail.com"},

--- a/src/samurai_backend/core/endpoints.py
+++ b/src/samurai_backend/core/endpoints.py
@@ -189,6 +189,22 @@ async def get_file(
     )
 
 
+@common_router.get(
+    "/file/{file_id}/info",
+)
+async def get_file_info(
+    db_session: Annotated[database_session_type, Depends(database_session)],
+    file_id: pydantic.UUID4,
+) -> FileRepresentation:
+    """Get information about a file by its ID."""
+    return FileRepresentation.model_validate(
+        get_file_by_id(
+            session=db_session,
+            file_id=file_id,
+        )
+    )
+
+
 @common_router.post(
     "/file",
 )


### PR DESCRIPTION
Added `GET /common/file/{file_id}/info` endpoint to view details of an uploaded file (like showing it in a comment, or a message) before downloading it.